### PR TITLE
feat(v2): add a badge that links to latest version

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -163,7 +163,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'hello.md'),
       title: 'Hello, World !',
       description: 'Hi, Endilie here :)',
-      isOld: false,
+      latestPermaLink: undefined,
     });
 
     expect(docsMetadata['foo/bar']).toEqual({
@@ -177,7 +177,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'foo', 'bar.md'),
       title: 'Bar',
       description: 'This is custom description',
-      isOld: false,
+      latestPermaLink: undefined,
     });
 
     expect(docsSidebars).toMatchSnapshot();
@@ -306,7 +306,7 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',
@@ -320,7 +320,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/next/foo/barSlug',
       },
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(docsMetadata['version-1.0.1/hello']).toEqual({
       id: 'version-1.0.1/hello',
@@ -339,7 +339,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/foo/bar',
       },
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(docsMetadata['version-1.0.0/foo/baz']).toEqual({
       id: 'version-1.0.0/foo/baz',
@@ -364,7 +364,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/1.0.0/foo/barSlug',
       },
-      isOld: true,
+      latestPermaLink: '@site/docs',
     });
 
     expect(docsSidebars).toMatchSnapshot('all sidebars');

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -163,7 +163,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'hello.md'),
       title: 'Hello, World !',
       description: 'Hi, Endilie here :)',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
 
     expect(docsMetadata['foo/bar']).toEqual({
@@ -177,7 +177,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'foo', 'bar.md'),
       title: 'Bar',
       description: 'This is custom description',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
 
     expect(docsSidebars).toMatchSnapshot();
@@ -306,7 +306,7 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
-      latestPermaLink: undefined,
+      latestPermalink: '/docs',
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',
@@ -320,7 +320,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/next/foo/barSlug',
       },
-      latestPermaLink: undefined,
+      latestPermalink: '/docs',
     });
     expect(docsMetadata['version-1.0.1/hello']).toEqual({
       id: 'version-1.0.1/hello',
@@ -339,7 +339,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/foo/bar',
       },
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
     expect(docsMetadata['version-1.0.0/foo/baz']).toEqual({
       id: 'version-1.0.0/foo/baz',
@@ -364,7 +364,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/1.0.0/foo/barSlug',
       },
-      latestPermaLink: '@site/docs',
+      latestPermalink: '/docs',
     });
 
     expect(docsSidebars).toMatchSnapshot('all sidebars');

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -163,6 +163,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'hello.md'),
       title: 'Hello, World !',
       description: 'Hi, Endilie here :)',
+      isOld:false
     });
 
     expect(docsMetadata['foo/bar']).toEqual({
@@ -176,6 +177,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'foo', 'bar.md'),
       title: 'Bar',
       description: 'This is custom description',
+      isOld:false
     });
 
     expect(docsSidebars).toMatchSnapshot();
@@ -304,6 +306,7 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
+      isOld:false
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',
@@ -317,6 +320,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/next/foo/barSlug',
       },
+      isOld:false
     });
     expect(docsMetadata['version-1.0.1/hello']).toEqual({
       id: 'version-1.0.1/hello',
@@ -335,6 +339,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/foo/bar',
       },
+      isOld:false
     });
     expect(docsMetadata['version-1.0.0/foo/baz']).toEqual({
       id: 'version-1.0.0/foo/baz',
@@ -359,6 +364,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/1.0.0/foo/barSlug',
       },
+      isOld:true
     });
 
     expect(docsSidebars).toMatchSnapshot('all sidebars');

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -163,7 +163,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'hello.md'),
       title: 'Hello, World !',
       description: 'Hi, Endilie here :)',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
 
     expect(docsMetadata['foo/bar']).toEqual({
@@ -177,7 +177,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'foo', 'bar.md'),
       title: 'Bar',
       description: 'This is custom description',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
 
     expect(docsSidebars).toMatchSnapshot();
@@ -337,7 +337,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/foo/bar',
       },
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
     expect(docsMetadata['version-1.0.0/foo/baz']).toEqual({
       id: 'version-1.0.0/foo/baz',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -306,7 +306,7 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
-      latestPermalink: '/docs',
+      
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',
@@ -320,7 +320,6 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/next/foo/barSlug',
       },
-      latestPermalink: '/docs',
     });
     expect(docsMetadata['version-1.0.1/hello']).toEqual({
       id: 'version-1.0.1/hello',
@@ -364,7 +363,6 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/1.0.0/foo/barSlug',
       },
-      latestPermalink: '/docs',
     });
 
     expect(docsSidebars).toMatchSnapshot('all sidebars');

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -306,7 +306,6 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
-      
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -163,7 +163,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'hello.md'),
       title: 'Hello, World !',
       description: 'Hi, Endilie here :)',
-      isOld:false
+      isOld: false,
     });
 
     expect(docsMetadata['foo/bar']).toEqual({
@@ -177,7 +177,7 @@ describe('simple website', () => {
       source: path.join('@site', pluginPath, 'foo', 'bar.md'),
       title: 'Bar',
       description: 'This is custom description',
-      isOld:false
+      isOld: false,
     });
 
     expect(docsSidebars).toMatchSnapshot();
@@ -306,7 +306,7 @@ describe('versioned website', () => {
         title: 'hello',
         permalink: '/docs/next/hello',
       },
-      isOld:false
+      isOld: false,
     });
     expect(docsMetadata['hello']).toEqual({
       id: 'hello',
@@ -320,7 +320,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/next/foo/barSlug',
       },
-      isOld:false
+      isOld: false,
     });
     expect(docsMetadata['version-1.0.1/hello']).toEqual({
       id: 'version-1.0.1/hello',
@@ -339,7 +339,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/foo/bar',
       },
-      isOld:false
+      isOld: false,
     });
     expect(docsMetadata['version-1.0.0/foo/baz']).toEqual({
       id: 'version-1.0.0/foo/baz',
@@ -364,7 +364,7 @@ describe('versioned website', () => {
         title: 'bar',
         permalink: '/docs/1.0.0/foo/barSlug',
       },
-      isOld:true
+      isOld: true,
     });
 
     expect(docsSidebars).toMatchSnapshot('all sidebars');

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -50,7 +50,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceA),
       title: 'Bar',
       description: 'This is custom description',
-      isOld:false
+      isOld: false,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -58,7 +58,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceB),
       title: 'Hello, World !',
       description: `Hi, Endilie here :)`,
-      isOld:false
+      isOld: false,
     });
   });
 
@@ -87,7 +87,7 @@ describe('simple site', () => {
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/docs/foo/baz.md',
       description: 'Images',
-      isOld:false
+      isOld: false,
     });
   });
 
@@ -112,7 +112,7 @@ describe('simple site', () => {
       title: 'lorem',
       editUrl: 'https://github.com/customUrl/docs/lorem.md',
       description: 'Lorem ipsum.',
-      isOld:false
+      isOld: false,
     });
 
     // unrelated frontmatter is not part of metadata
@@ -144,7 +144,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      isOld:false
+      isOld: false,
     });
   });
 
@@ -173,7 +173,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      isOld:false
+      isOld: false,
     });
   });
 
@@ -255,7 +255,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'This is next version of bar.',
       version: 'next',
-      isOld:false
+      isOld: false,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -264,7 +264,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello next !',
       version: 'next',
-      isOld:false
+      isOld: false,
     });
   });
 
@@ -315,7 +315,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.0 !',
       version: '1.0.0',
-      isOld:true
+      isOld: true,
     });
     expect(dataB).toEqual({
       id: 'version-1.0.0/hello',
@@ -324,7 +324,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.0 !',
       version: '1.0.0',
-      isOld:true
+      isOld: true,
     });
     expect(dataC).toEqual({
       id: 'version-1.0.1/foo/bar',
@@ -333,7 +333,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.1 !',
       version: '1.0.1',
-      isOld:false
+      isOld: false,
     });
     expect(dataD).toEqual({
       id: 'version-1.0.1/hello',
@@ -342,7 +342,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.1 !',
       version: '1.0.1',
-      isOld:false
+      isOld: false,
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -50,6 +50,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceA),
       title: 'Bar',
       description: 'This is custom description',
+      isOld:false
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -57,6 +58,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceB),
       title: 'Hello, World !',
       description: `Hi, Endilie here :)`,
+      isOld:false
     });
   });
 
@@ -85,6 +87,7 @@ describe('simple site', () => {
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/docs/foo/baz.md',
       description: 'Images',
+      isOld:false
     });
   });
 
@@ -109,6 +112,7 @@ describe('simple site', () => {
       title: 'lorem',
       editUrl: 'https://github.com/customUrl/docs/lorem.md',
       description: 'Lorem ipsum.',
+      isOld:false
     });
 
     // unrelated frontmatter is not part of metadata
@@ -140,6 +144,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
+      isOld:false
     });
   });
 
@@ -168,6 +173,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
+      isOld:false
     });
   });
 
@@ -249,6 +255,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'This is next version of bar.',
       version: 'next',
+      isOld:false
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -257,6 +264,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello next !',
       version: 'next',
+      isOld:false
     });
   });
 
@@ -307,6 +315,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.0 !',
       version: '1.0.0',
+      isOld:true
     });
     expect(dataB).toEqual({
       id: 'version-1.0.0/hello',
@@ -315,6 +324,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.0 !',
       version: '1.0.0',
+      isOld:true
     });
     expect(dataC).toEqual({
       id: 'version-1.0.1/foo/bar',
@@ -323,6 +333,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.1 !',
       version: '1.0.1',
+      isOld:false
     });
     expect(dataD).toEqual({
       id: 'version-1.0.1/hello',
@@ -331,6 +342,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.1 !',
       version: '1.0.1',
+      isOld:false
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -50,7 +50,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceA),
       title: 'Bar',
       description: 'This is custom description',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -58,7 +58,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceB),
       title: 'Hello, World !',
       description: `Hi, Endilie here :)`,
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
   });
 
@@ -87,7 +87,7 @@ describe('simple site', () => {
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/docs/foo/baz.md',
       description: 'Images',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
   });
 
@@ -112,7 +112,7 @@ describe('simple site', () => {
       title: 'lorem',
       editUrl: 'https://github.com/customUrl/docs/lorem.md',
       description: 'Lorem ipsum.',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
 
     // unrelated frontmatter is not part of metadata
@@ -144,7 +144,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
   });
 
@@ -173,7 +173,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      latestPermalink: undefined,
+      latestVersionMainDocPermalink: undefined,
     });
   });
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -255,7 +255,6 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'This is next version of bar.',
       version: 'next',
-      latestPermalink: '/docs',
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -264,7 +263,6 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello next !',
       version: 'next',
-      latestPermalink: '/docs',
     });
   });
 
@@ -315,7 +313,6 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.0 !',
       version: '1.0.0',
-      latestPermalink: '/docs',
     });
     expect(dataB).toEqual({
       id: 'version-1.0.0/hello',
@@ -324,7 +321,6 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.0 !',
       version: '1.0.0',
-      latestPermalink: '/docs',
     });
     expect(dataC).toEqual({
       id: 'version-1.0.1/foo/bar',
@@ -333,7 +329,6 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.1 !',
       version: '1.0.1',
-      latestPermalink: undefined,
     });
     expect(dataD).toEqual({
       id: 'version-1.0.1/hello',
@@ -342,7 +337,6 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.1 !',
       version: '1.0.1',
-      latestPermalink: undefined,
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -50,7 +50,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceA),
       title: 'Bar',
       description: 'This is custom description',
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -58,7 +58,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceB),
       title: 'Hello, World !',
       description: `Hi, Endilie here :)`,
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 
@@ -87,7 +87,7 @@ describe('simple site', () => {
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/docs/foo/baz.md',
       description: 'Images',
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 
@@ -112,7 +112,7 @@ describe('simple site', () => {
       title: 'lorem',
       editUrl: 'https://github.com/customUrl/docs/lorem.md',
       description: 'Lorem ipsum.',
-      isOld: false,
+      latestPermaLink: undefined,
     });
 
     // unrelated frontmatter is not part of metadata
@@ -144,7 +144,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 
@@ -173,7 +173,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 
@@ -255,7 +255,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'This is next version of bar.',
       version: 'next',
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -264,7 +264,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello next !',
       version: 'next',
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 
@@ -315,7 +315,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.0 !',
       version: '1.0.0',
-      isOld: true,
+      latestPermaLink: '@site/docs',
     });
     expect(dataB).toEqual({
       id: 'version-1.0.0/hello',
@@ -324,7 +324,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.0 !',
       version: '1.0.0',
-      isOld: true,
+      latestPermaLink: '@site/docs',
     });
     expect(dataC).toEqual({
       id: 'version-1.0.1/foo/bar',
@@ -333,7 +333,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.1 !',
       version: '1.0.1',
-      isOld: false,
+      latestPermaLink: undefined,
     });
     expect(dataD).toEqual({
       id: 'version-1.0.1/hello',
@@ -342,7 +342,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.1 !',
       version: '1.0.1',
-      isOld: false,
+      latestPermaLink: undefined,
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -50,7 +50,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceA),
       title: 'Bar',
       description: 'This is custom description',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -58,7 +58,7 @@ describe('simple site', () => {
       source: path.join('@site', routeBasePath, sourceB),
       title: 'Hello, World !',
       description: `Hi, Endilie here :)`,
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
   });
 
@@ -87,7 +87,7 @@ describe('simple site', () => {
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/docs/foo/baz.md',
       description: 'Images',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
   });
 
@@ -112,7 +112,7 @@ describe('simple site', () => {
       title: 'lorem',
       editUrl: 'https://github.com/customUrl/docs/lorem.md',
       description: 'Lorem ipsum.',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
 
     // unrelated frontmatter is not part of metadata
@@ -144,7 +144,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
   });
 
@@ -173,7 +173,7 @@ describe('simple site', () => {
       description: 'Lorem ipsum.',
       lastUpdatedAt: 1539502055,
       lastUpdatedBy: 'Author',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
   });
 
@@ -255,7 +255,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'This is next version of bar.',
       version: 'next',
-      latestPermaLink: undefined,
+      latestPermalink: '/docs',
     });
     expect(dataB).toEqual({
       id: 'hello',
@@ -264,7 +264,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello next !',
       version: 'next',
-      latestPermaLink: undefined,
+      latestPermalink: '/docs',
     });
   });
 
@@ -315,7 +315,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.0 !',
       version: '1.0.0',
-      latestPermaLink: '@site/docs',
+      latestPermalink: '/docs',
     });
     expect(dataB).toEqual({
       id: 'version-1.0.0/hello',
@@ -324,7 +324,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.0 !',
       version: '1.0.0',
-      latestPermaLink: '@site/docs',
+      latestPermalink: '/docs',
     });
     expect(dataC).toEqual({
       id: 'version-1.0.1/foo/bar',
@@ -333,7 +333,7 @@ describe('versioned site', () => {
       title: 'bar',
       description: 'Bar 1.0.1 !',
       version: '1.0.1',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
     expect(dataD).toEqual({
       id: 'version-1.0.1/hello',
@@ -342,7 +342,7 @@ describe('versioned site', () => {
       title: 'hello',
       description: 'Hello 1.0.1 !',
       version: '1.0.1',
-      latestPermaLink: undefined,
+      latestPermalink: undefined,
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -384,12 +384,7 @@ Available document ids=
                 homePageDocsRoutePath,
                 versionDocsPathPrefix,
               ]);
-              if (metadataItem.latestPermalink) {
-                metadataItem.latestPermalink = normalizeUrl([
-                  baseUrl,
-                  homePageDocsRoutePath,
-                ]);
-              }
+
               const docsBaseMetadataPath = await createData(
                 `${docuHash(metadataItem.source)}-base.json`,
                 JSON.stringify(docsBaseMetadata, null, 2),

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -476,7 +476,7 @@ Available document ids=
         );
         const rootUrl =
           options.homePageId && content.docsMetadata[options.homePageId]
-            ? content.docsMetadata[options.homePageId].permalink
+            ? normalizeUrl([baseUrl, routeBasePath])
             : getFirstDocLinkOfSidebar(
                 content.docsSidebars[
                   `version-${versioning.latestVersion}/docs`

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -65,10 +65,10 @@ const DEFAULT_OPTIONS: PluginOptions = {
   admonitions: {},
 };
 
-function getHrefFromSideBar(sidebarItems: DocsSidebarItem[]): string | null {
+function getFirstDocLinkOfSidebar(sidebarItems: DocsSidebarItem[]): string | null {
   for (let sidebarItem of sidebarItems) {
     if (sidebarItem.type === 'category') {
-      const url = getHrefFromSideBar(sidebarItem.items);
+      const url = getFirstDocLinkOfSidebar(sidebarItem.items);
       if (url) return url;
     } else {
       return sidebarItem.href;
@@ -472,17 +472,20 @@ Available document ids=
           Object.values(content.docsMetadata),
           'version',
         );
-        const rootUrl = options.homePageId
-          ? normalizeUrl([baseUrl, homePageDocsRoutePath])
-          : getHrefFromSideBar(
-              content.docsSidebars[`version-${versioning.latestVersion}/docs`],
-            );
+        const rootUrl =
+          options.homePageId && content.docsMetadata[options.homePageId]
+            ? content.docsMetadata[options.homePageId].permalink
+            : getFirstDocLinkOfSidebar(
+                content.docsSidebars[
+                  `version-${versioning.latestVersion}/docs`
+                ],
+              );
         if (!rootUrl) {
           throw new Error('Bad sidebars file. No document linked');
         }
         Object.values(content.docsMetadata).forEach((docMetadata) => {
           if (docMetadata.version !== versioning.latestVersion)
-            docMetadata.latestPermalink = rootUrl;
+            docMetadata.latestVersionMainDocPermalink = rootUrl;
         });
         await Promise.all(
           Object.keys(docsMetadataByVersion).map(async (version) => {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -472,9 +472,11 @@ Available document ids=
           Object.values(content.docsMetadata),
           'version',
         );
-        const rootUrl = getHrefFromSideBar(
-          content.docsSidebars[`version-${versioning.latestVersion}/docs`],
-        );
+        const rootUrl = options.homePageId
+          ? normalizeUrl([baseUrl, homePageDocsRoutePath])
+          : getHrefFromSideBar(
+              content.docsSidebars[`version-${versioning.latestVersion}/docs`],
+            );
         if (!rootUrl) {
           throw new Error('Bad sidebars file. No document linked');
         }

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -384,6 +384,12 @@ Available document ids=
                 homePageDocsRoutePath,
                 versionDocsPathPrefix,
               ]);
+              if (metadataItem.latestPermalink) {
+                metadataItem.latestPermalink = normalizeUrl([
+                  baseUrl,
+                  homePageDocsRoutePath,
+                ]);
+              }
               const docsBaseMetadataPath = await createData(
                 `${docuHash(metadataItem.source)}-base.json`,
                 JSON.stringify(docsBaseMetadata, null, 2),

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -65,7 +65,9 @@ const DEFAULT_OPTIONS: PluginOptions = {
   admonitions: {},
 };
 
-function getFirstDocLinkOfSidebar(sidebarItems: DocsSidebarItem[]): string | null {
+function getFirstDocLinkOfSidebar(
+  sidebarItems: DocsSidebarItem[],
+): string | null {
   for (let sidebarItem of sidebarItems) {
     if (sidebarItem.type === 'category') {
       const url = getFirstDocLinkOfSidebar(sidebarItem.items);

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -71,7 +71,9 @@ function getFirstDocLinkOfSidebar(
   for (let sidebarItem of sidebarItems) {
     if (sidebarItem.type === 'category') {
       const url = getFirstDocLinkOfSidebar(sidebarItem.items);
-      if (url) return url;
+      if (url) {
+        return url;
+      }
     } else {
       return sidebarItem.href;
     }
@@ -486,8 +488,9 @@ Available document ids=
           throw new Error('Bad sidebars file. No document linked');
         }
         Object.values(content.docsMetadata).forEach((docMetadata) => {
-          if (docMetadata.version !== versioning.latestVersion)
+          if (docMetadata.version !== versioning.latestVersion) {
             docMetadata.latestVersionMainDocPermalink = rootUrl;
+          }
         });
         await Promise.all(
           Object.keys(docsMetadataByVersion).map(async (version) => {

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -128,11 +128,6 @@ export default async function processMetadata({
     routePath,
   ]);
 
-  const latestPermalink =
-    version && version !== versioning.latestVersion
-      ? normalizeUrl([baseUrl, routeBasePath])
-      : undefined;
-
   const {lastUpdatedAt, lastUpdatedBy} = await lastUpdatedPromise;
 
   // Assign all of object properties during instantiation (if possible) for
@@ -150,7 +145,6 @@ export default async function processMetadata({
     lastUpdatedBy,
     lastUpdatedAt,
     sidebar_label,
-    latestPermalink,
   };
 
   return metadata;

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -130,7 +130,7 @@ export default async function processMetadata({
 
   const latestPermalink =
     version && version !== versioning.latestVersion
-      ? normalizeUrl([baseUrl, routeBasePath, routePath])
+      ? normalizeUrl([baseUrl, routeBasePath])
       : undefined;
 
   const {lastUpdatedAt, lastUpdatedBy} = await lastUpdatedPromise;

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -88,7 +88,7 @@ export default async function processMetadata({
     version && version !== versioning.latestVersion ? version : '';
 
   const isOld =
-    version && version !== 'next' ? version !== versioning.latestVersion : true;
+    version && version !== 'next' ? version !== versioning.latestVersion : false;
 
   const relativePath = path.relative(siteDir, filePath);
 

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -88,7 +88,9 @@ export default async function processMetadata({
     version && version !== versioning.latestVersion ? version : '';
 
   const isOld =
-    version && version !== 'next' ? version !== versioning.latestVersion : false;
+    version && version !== 'next'
+      ? version !== versioning.latestVersion
+      : false;
 
   const relativePath = path.relative(siteDir, filePath);
 

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -87,6 +87,9 @@ export default async function processMetadata({
   const versionPath =
     version && version !== versioning.latestVersion ? version : '';
 
+  const isOld =
+    version && version !== 'next' ? version !== versioning.latestVersion : true;
+
   const relativePath = path.relative(siteDir, filePath);
 
   const docsEditUrl = getEditUrl(relativePath, editUrl);
@@ -145,6 +148,7 @@ export default async function processMetadata({
     lastUpdatedBy,
     lastUpdatedAt,
     sidebar_label,
+    isOld,
   };
 
   return metadata;

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -87,11 +87,6 @@ export default async function processMetadata({
   const versionPath =
     version && version !== versioning.latestVersion ? version : '';
 
-  const isOld =
-    version && version !== 'next'
-      ? version !== versioning.latestVersion
-      : false;
-
   const relativePath = path.relative(siteDir, filePath);
 
   const docsEditUrl = getEditUrl(relativePath, editUrl);
@@ -133,6 +128,11 @@ export default async function processMetadata({
     routePath,
   ]);
 
+  const latestPermalink =
+    version && version !== versioning.latestVersion
+      ? normalizeUrl([baseUrl, routeBasePath, routePath])
+      : undefined;
+
   const {lastUpdatedAt, lastUpdatedBy} = await lastUpdatedPromise;
 
   // Assign all of object properties during instantiation (if possible) for
@@ -150,7 +150,7 @@ export default async function processMetadata({
     lastUpdatedBy,
     lastUpdatedAt,
     sidebar_label,
-    isOld,
+    latestPermalink,
   };
 
   return metadata;

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -118,6 +118,7 @@ export interface MetadataRaw extends LastUpdateData {
   sidebar_label?: string;
   editUrl?: string;
   version?: string;
+  isOld?: boolean;
 }
 
 export interface Paginator {

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -118,7 +118,7 @@ export interface MetadataRaw extends LastUpdateData {
   sidebar_label?: string;
   editUrl?: string;
   version?: string;
-  latestPermalink?: string;
+  latestVersionMainDocPermalink?: string;
 }
 
 export interface Paginator {

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -118,7 +118,7 @@ export interface MetadataRaw extends LastUpdateData {
   sidebar_label?: string;
   editUrl?: string;
   version?: string;
-  isOld?: boolean;
+  latestPermalink?: string;
 }
 
 export interface Paginator {

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -121,7 +121,7 @@ function DocItem(props) {
                         <a href="/docs"> Go to latest version </a>
                       </span>
                     ) : null}
-                  </div>  
+                  </div>
                 )}
                 {!hideTitle && (
                   <header>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -69,7 +69,7 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     version,
-    isOld,
+    latestPermalink
   } = metadata;
   const {
     frontMatter: {
@@ -117,9 +117,9 @@ function DocItem(props) {
                     <span className="badge badge--secondary">
                       Version: {version}
                     </span>
-                    {isOld ? (
+                    {latestPermalink ? (
                       <span className="badge badge--secondary margin-horiz--xs">
-                        <Link to="/docs"> Go to latest version </Link>
+                        <Link to={latestPermalink}> Go to latest version </Link>
                       </span>
                     ) : null}
                   </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -114,12 +114,19 @@ function DocItem(props) {
               <div
                 className="alert alert--danger margin-bottom--md"
                 role="alert">
-                <div className="margin-bottom--md">
-                  This is archived documentation for Docusaurus{' '}
-                  <strong>{version}</strong>, which is no longer actively
-                  maintained.
-                </div>
-                <div>
+                {version === 'next' ? (
+                  <div>
+                    This is unreleased documentation for {siteTitle}{' '}
+                    <strong>{version}</strong> version.
+                  </div>
+                ) : (
+                  <div>
+                    This is archived documentation for {siteTitle}{' '}
+                    <strong>v{version}</strong>, which is no longer actively
+                    maintained.
+                  </div>
+                )}
+                <div className="margin-top--md">
                   For up-to-date documentation, see the{' '}
                   <strong>
                     <Link to={latestPermalink}>latest version</Link>.

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -12,6 +12,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import DocPaginator from '@theme/DocPaginator';
 import useTOCHighlight from '@theme/hooks/useTOCHighlight';
+import Link from '@docusaurus/Link';
 
 import clsx from 'clsx';
 import styles from './styles.module.css';
@@ -118,7 +119,7 @@ function DocItem(props) {
                     </span>
                     {isOld ? (
                       <span className="badge badge--secondary margin-horiz--xs">
-                        <a href="/docs"> Go to latest version </a>
+                        <Link to="/docs"> Go to latest version </Link>
                       </span>
                     ) : null}
                   </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -69,7 +69,7 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     version,
-    latestPermalink
+    latestPermalink,
   } = metadata;
   const {
     frontMatter: {
@@ -105,6 +105,16 @@ function DocItem(props) {
       </Head>
       <div
         className={clsx('container padding-vert--lg', styles.docItemWrapper)}>
+        {latestPermalink && (
+          <div class="alert alert--danger margin-bottom--md" role="alert">
+            This is archived documentation for Docusaurus{' '}
+            <strong>{version}</strong>, which is no longer actively maintained.
+            <br />
+            <br />
+            For up-to-date documentation, see the{' '}
+            <Link to={latestPermalink}> latest version </Link>.
+          </div>
+        )}
         <div className="row">
           <div
             className={clsx('col', {
@@ -117,11 +127,6 @@ function DocItem(props) {
                     <span className="badge badge--secondary">
                       Version: {version}
                     </span>
-                    {latestPermalink ? (
-                      <span className="badge badge--secondary margin-horiz--xs">
-                        <Link to={latestPermalink}> Go to latest version </Link>
-                      </span>
-                    ) : null}
                   </div>
                 )}
                 {!hideTitle && (

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -129,7 +129,10 @@ function DocItem(props) {
                 <div className="margin-top--md">
                   For up-to-date documentation, see the{' '}
                   <strong>
-                    <Link to={latestVersionMainDocPermalink}>latest version</Link>.
+                    <Link to={latestVersionMainDocPermalink}>
+                      latest version
+                    </Link>
+                    .
                   </strong>
                 </div>
               </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -69,7 +69,7 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     version,
-    latestPermalink,
+    latestVersionMainDocPermalink,
   } = metadata;
   const {
     frontMatter: {
@@ -110,7 +110,7 @@ function DocItem(props) {
             className={clsx('col', {
               [styles.docItemCol]: !hideTableOfContents,
             })}>
-            {latestPermalink && (
+            {latestVersionMainDocPermalink && (
               <div
                 className="alert alert--warning margin-bottom--md"
                 role="alert">
@@ -129,7 +129,7 @@ function DocItem(props) {
                 <div className="margin-top--md">
                   For up-to-date documentation, see the{' '}
                   <strong>
-                    <Link to={latestPermalink}>latest version</Link>.
+                    <Link to={latestVersionMainDocPermalink}>latest version</Link>.
                   </strong>
                 </div>
               </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -112,7 +112,7 @@ function DocItem(props) {
             })}>
             {latestPermalink && (
               <div
-                className="alert alert--danger margin-bottom--md"
+                className="alert alert--warning margin-bottom--md"
                 role="alert">
                 {version === 'next' ? (
                   <div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -105,21 +105,28 @@ function DocItem(props) {
       </Head>
       <div
         className={clsx('container padding-vert--lg', styles.docItemWrapper)}>
-        {latestPermalink && (
-          <div class="alert alert--danger margin-bottom--md" role="alert">
-            This is archived documentation for Docusaurus{' '}
-            <strong>{version}</strong>, which is no longer actively maintained.
-            <br />
-            <br />
-            For up-to-date documentation, see the{' '}
-            <Link to={latestPermalink}> latest version </Link>.
-          </div>
-        )}
         <div className="row">
           <div
             className={clsx('col', {
               [styles.docItemCol]: !hideTableOfContents,
             })}>
+            {latestPermalink && (
+              <div
+                className="alert alert--danger margin-bottom--md"
+                role="alert">
+                <div className="margin-bottom--md">
+                  This is archived documentation for Docusaurus{' '}
+                  <strong>{version}</strong>, which is no longer actively
+                  maintained.
+                </div>
+                <div>
+                  For up-to-date documentation, see the{' '}
+                  <strong>
+                    <Link to={latestPermalink}>latest version</Link>.
+                  </strong>
+                </div>
+              </div>
+            )}
             <div className={styles.docItemContainer}>
               <article>
                 {version && (

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -68,6 +68,7 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     version,
+    isOld,
   } = metadata;
   const {
     frontMatter: {
@@ -115,7 +116,12 @@ function DocItem(props) {
                     <span className="badge badge--secondary">
                       Version: {version}
                     </span>
-                  </div>
+                    {isOld ? (
+                      <span className="badge badge--secondary margin-horiz--xs">
+                        <a href="/docs"> Go to latest version </a>
+                      </span>
+                    ) : null}
+                  </div>  
                 )}
                 {!hideTitle && (
                   <header>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -132,8 +132,8 @@ function DocItem(props) {
                     <Link to={latestVersionMainDocPermalink}>
                       latest version
                     </Link>
-                    .
                   </strong>
+                  .
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Motivation

This PR adds a badge that links older versions of documentation to the latest version of the documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan 
1. Go to any older version in the preview site. Check that there is a badge that links to the latest version
![image](https://user-images.githubusercontent.com/46853051/84246362-1b6f8380-ab39-11ea-96da-ffb5e8718c17.png)
1. Click on the link to the latest version. There should be no badge next to the version number, since we are now at the latest version
![image](https://user-images.githubusercontent.com/46853051/84246449-39d57f00-ab39-11ea-97bd-78e59cd4dbf4.png)

Preview: https://deploy-preview-2915--docusaurus-2.netlify.app
